### PR TITLE
fix action warnings about old node version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,11 +25,11 @@ jobs:
             MEMORY_CHECK: ${{ matrix.memcheck }}
         steps:
             - name: 'Check out repository'
-              uses: 'actions/checkout@v2'
+              uses: 'actions/checkout@v4'
               with:
                   path: 'php-inotify'
 
-            - uses: actions/cache@v2
+            - uses: actions/cache@v4
               with:
                   path: ~/build-cache/php
                   key: ${{ matrix.os }}-${{ matrix.php }}-${{ matrix.memcheck }}


### PR DESCRIPTION
This is just a small drive-by PR to update the `checkout` and `cache` actions from `v2` to `v4` to get rid of the warnings about an outdated nodejs version being used.